### PR TITLE
modernize spec file

### DIFF
--- a/prunerepo.spec
+++ b/prunerepo.spec
@@ -20,7 +20,9 @@ License: GPL-2.0-or-later
 BuildArch: noarch
 BuildRequires: bash
 BuildRequires: python3-devel
+%if 0%{?rhel} && 0%{?rhel} <= 10
 BuildRequires: python3-setuptools
+%endif
 BuildRequires: python3-rpm
 BuildRequires: createrepo_c
 BuildRequires: asciidoc
@@ -59,24 +61,44 @@ to recreate the repository metadata.
 
 %prep
 %setup -q
+%if 0%{?rhel} && 0%{?rhel} <= 10
+rm -f pyproject.toml
+%endif
 
 %check
 tests/run.sh
 
+%if 0%{?fedora}
+%generate_buildrequires
+%pyproject_buildrequires
+%endif
+
 %build
+%if 0%{?fedora}
+%pyproject_wheel
+%else
 name="%{name}" version="%{version}" summary="%{summary}" %py3_build
+%endif
 a2x -d manpage -f manpage man/prunerepo.1.asciidoc
 
 %install
+%if 0%{?fedora}
+%pyproject_install
+%pyproject_save_files -l prunerepo
+%else
 name="%{name}" version="%{version}" summary="%{summary}" %py3_install
+%endif
 
 install -d %{buildroot}%{_mandir}/man1
 install -p -m 644 man/prunerepo.1 %{buildroot}/%{_mandir}/man1/
 
+%if 0%{?fedora}
+%files -f %{pyproject_files}
+%else
 %files
 %license LICENSE
-
 %{python3_sitelib}/*
+%endif
 %{_bindir}/prunerepo
 %{_mandir}/man1/prunerepo.1*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prunerepo"
+version = "1.26"
+description = "Remove old packages from rpm-md repository"
+license = "GPL-2.0-or-later"
+license-files = ["LICENSE"]
+authors = [
+    {name = "copr-team", email = "copr-team@redhat.com"},
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Build Tools",
+]
+requires-python = ">=3.6"
+
+[project.scripts]
+prunerepo = "prunerepo.main:main"
+
+[tool.setuptools]
+packages = ["prunerepo"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# This file is used only for EPEL 10 (and older) compatibility.
+# Fedora builds use pyproject.toml with %pyproject_* macros.
 
 import os
 


### PR DESCRIPTION
Replace setup.py-based build with pyproject.toml and use %pyproject_wheel, %pyproject_install, %pyproject_buildrequires, and %pyproject_save_files macros.

- %py3_build → %pyproject_wheel (setup.py install deprecated in F45)
- %py3_install → %pyproject_install
- Add %generate_buildrequires with %pyproject_buildrequires
- Add %pyproject_save_files for proper file listing
- Drop explicit python3-setuptools BR (auto-generated now)
- Replace setup.py with pyproject.toml using PEP 639 license expression
- Remove deprecated license classifier

Resolves: rhbz#2377378

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>